### PR TITLE
Generate IronMeta on build

### DIFF
--- a/src/Core/Gibberish/Gibberish.csproj
+++ b/src/Core/Gibberish/Gibberish.csproj
@@ -83,11 +83,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
+    <Exec Command="..\packages\IronMeta.4.2.3\tools\IronMeta.exe -o ParseFasm.g.cs ParseFasm.ironmeta" />
   </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/src/Core/Gibberish/ParseFasm.g.cs
+++ b/src/Core/Gibberish/ParseFasm.g.cs
@@ -1,5 +1,5 @@
-﻿//
-// IronMeta ParseFasm Parser; Generated 2015-12-22 07:35:10Z UTC
+//
+// IronMeta ParseFasm Parser; Generated 2015-12-31 13:10:24Z UTC
 //
 
 using System;
@@ -1047,9 +1047,7 @@ namespace Gibberish
 
         static readonly Verophyle.Regexp.StringRegexp _re0 = new Verophyle.Regexp.StringRegexp(@"[a-zA-z0-9_.]+");
 
-    }
-
-	// class ParseFasm
+    } // class ParseFasm
 
 } // namespace Gibberish
 


### PR DESCRIPTION
Visual Studio runs IronMeta when you save the .ironmeta file, but if you
modify the file outside of VS, or you make a change that the .ironmeta
file depends on, it won't regenerate, and you can have a bug.

To avoid that problem, run ironmeta.exe as a before-build task, to make
sure the generated file is up to date.

I only did this for ParseFasm, since it's currently the only .ironmeta
we're currently working with. We could build proper MSBuild targets and
tasks for this in the future.
