### PR TITLE
Fix ironmeta on mono

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: csharp
+solution: src/Core/Core.sln

--- a/src/Core/Gibberish/Gibberish.csproj
+++ b/src/Core/Gibberish/Gibberish.csproj
@@ -84,6 +84,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="BeforeBuild">
-    <Exec Command="..\packages\IronMeta.4.2.3\tools\IronMeta.exe -o ParseFasm.g.cs ParseFasm.ironmeta" />
+    <Exec Condition=" $(OS) == 'Windows_NT'" Command="     ..\packages\IronMeta.4.2.3\tools\IronMeta.exe -o ParseFasm.g.cs ParseFasm.ironmeta" />
+    <Exec Condition=" $(OS) != 'Windows_NT'" Command="mono ..\packages\IronMeta.4.2.3\tools\IronMeta.exe -o ParseFasm.g.cs ParseFasm.ironmeta" />
   </Target>
 </Project>


### PR DESCRIPTION
The build fails later, at least on Travis, due to not being compatible with the latest MSBuild.
